### PR TITLE
CheckImports plugin

### DIFF
--- a/examples/A.hs
+++ b/examples/A.hs
@@ -2,6 +2,5 @@
 
 module A (test) where
 
-
 test :: IO ()
 test = putStrLn "test"

--- a/examples/A.hs
+++ b/examples/A.hs
@@ -1,0 +1,7 @@
+{-# OPTIONS_GHC -fplugin Plugin.CheckImports #-}
+
+module A (test) where
+
+
+test :: IO ()
+test = putStrLn "test"

--- a/examples/A.hs
+++ b/examples/A.hs
@@ -2,6 +2,9 @@
 -- -fplugin (plugin_module).
 -- If one specifies the arguments in the ghc-options field in the cabal file,
 -- the plugin will be operated over all the modules in the package.
+-- The plugin module should be visible to ghc, so the package that defines
+-- the module should be a dependency in the cabal package, or alternatively,
+-- -plugin-package (package_name) can be specified.
 --
 -- To turn on a plugin only for a specific module, one can use the OPTIONS_GHC pragma
 -- with the plugin arguments like this example.

--- a/examples/A.hs
+++ b/examples/A.hs
@@ -1,3 +1,13 @@
+-- NOTE: To use a GHC plugin, one can turn it on by the GHC CLI arguments:
+-- -fplugin (plugin_module).
+-- If one specifies the arguments in the ghc-options field in the cabal file,
+-- the plugin will be operated over all the modules in the package.
+--
+-- To turn on a plugin only for a specific module, one can use the OPTIONS_GHC pragma
+-- with the plugin arguments like this example.
+--
+-- In this case, the Plugin.CheckImports module will be invoked as plugin as the module
+-- defines a function with the reserved keyword "plugin".
 {-# OPTIONS_GHC -fplugin Plugin.CheckImports #-}
 
 module A (test) where

--- a/package.yaml
+++ b/package.yaml
@@ -72,7 +72,6 @@ dependencies:
 
 ghc-options:
   - -Wall
-  # - -ddump-json -dshow-passes
 
 extra-source-files:
   - README.md

--- a/package.yaml
+++ b/package.yaml
@@ -9,6 +9,7 @@ description: Please see the README on GitHub at
 category: Development
 author:
   - Rebecca Turner <rebeccat@mercury.com>
+  - Ian-Woo Kim <iank@mercury.com>
 copyright: © 2022 Mercury Inc. All rights reserved.
 
 default-extensions:
@@ -71,13 +72,17 @@ dependencies:
 
 ghc-options:
   - -Wall
-  - -ddump-json -dshow-passes
+  # - -ddump-json -dshow-passes
 
 extra-source-files:
   - README.md
 
 library:
   source-dirs: src
+  dependencies:
+    - containers
+    - ghc == 9.2.*
+    - transformers
 
 executables:
   ghc-build-analyzer-exe:

--- a/src/Plugin/CheckImports.hs
+++ b/src/Plugin/CheckImports.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Plugin.CheckImports (
+    plugin,
+) where
+
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Char (isAlpha)
+import Data.Foldable (for_)
+import Data.IORef (readIORef)
+import Data.List (foldl', sort)
+import Data.Map (Map)
+import qualified Data.Map as M
+import Data.Set (Set)
+import qualified Data.Set as S
+import GHC.Data.IOEnv (failWithM)
+import GHC.Driver.Session (DynFlags, getDynFlags)
+import GHC.Plugins (
+    CommandLineOption,
+    ModSummary,
+    Name,
+    Plugin (..),
+    defaultPlugin,
+    localiseName,
+    showSDoc,
+ )
+import GHC.Tc.Types (TcGblEnv (..), TcM)
+import GHC.Types.Name.Reader (
+    GlobalRdrElt (..),
+    GreName (..),
+    ImpDeclSpec (..),
+    ImportSpec (..),
+ )
+import GHC.Unit.Module (ModuleName)
+import GHC.Utils.Outputable (Outputable (ppr))
+import Prelude hiding ((<>))
+
+plugin :: Plugin
+plugin =
+    defaultPlugin
+        { typeCheckResultAction = typecheckPlugin
+        }
+
+printPpr :: (Outputable a, MonadIO m) => DynFlags -> a -> m ()
+printPpr dflags = liftIO . putStrLn . showSDoc dflags . ppr
+
+formatName :: DynFlags -> Name -> String
+formatName dflags name =
+    let str = showSDoc dflags . ppr . localiseName $ name
+     in case str of
+            (x : _) ->
+                if isAlpha x
+                    then str
+                    else "(" ++ str ++ ")"
+            _ -> str
+
+formatImportedNames :: [String] -> String
+formatImportedNames names =
+    case fmap (++ ",\n") $ sort names of
+        l0 : ls ->
+            let l0' = "  ( " ++ l0
+                ls' = fmap ("    " ++) ls
+                footer = "  )"
+             in concat ([l0'] ++ ls' ++ [footer])
+        _ -> "  ()"
+
+mkModuleNameMap :: GlobalRdrElt -> [(ModuleName, Name)]
+mkModuleNameMap gre = do
+    spec <- gre_imp gre
+    case gre_name gre of
+        NormalGreName name -> do
+            let modName = is_mod $ is_decl spec
+            pure (modName, name)
+        _ -> []
+
+typecheckPlugin ::
+    [CommandLineOption] ->
+    ModSummary ->
+    TcGblEnv ->
+    TcM TcGblEnv
+typecheckPlugin _ modsummary tc = do
+    liftIO $ putStrLn "typecheck plugin"
+    dflags <- getDynFlags
+    usedGREs :: [GlobalRdrElt] <-
+        liftIO $ readIORef (tcg_used_gres tc)
+    let moduleImportMap :: Map ModuleName (Set Name)
+        moduleImportMap =
+            foldl' (\(!m) (modu, name) -> M.insertWith S.union modu (S.singleton name) m) M.empty $
+                concatMap mkModuleNameMap usedGREs
+    for_ (M.toList moduleImportMap) $ \(modu, names) -> liftIO $ do
+        putStrLn "---------"
+        printPpr dflags modu
+        let imported = fmap (formatName dflags) $ S.toList names
+        putStrLn $ formatImportedNames imported
+    printPpr dflags modsummary
+    -- _ <- failWithM "force fail"
+    pure tc

--- a/src/Plugin/CheckImports.hs
+++ b/src/Plugin/CheckImports.hs
@@ -80,7 +80,6 @@ typecheckPlugin ::
     TcGblEnv ->
     TcM TcGblEnv
 typecheckPlugin _ modsummary tc = do
-    liftIO $ putStrLn "typecheck plugin"
     dflags <- getDynFlags
     usedGREs :: [GlobalRdrElt] <-
         liftIO $ readIORef (tcg_used_gres tc)
@@ -94,5 +93,4 @@ typecheckPlugin _ modsummary tc = do
         let imported = fmap (formatName dflags) $ S.toList names
         putStrLn $ formatImportedNames imported
     printPpr dflags modsummary
-    -- _ <- failWithM "force fail"
     pure tc

--- a/src/Plugin/CheckImports.hs
+++ b/src/Plugin/CheckImports.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Plugin.CheckImports (
-    plugin,
-) where
+module Plugin.CheckImports
+  ( plugin,
+  )
+where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Char (isAlpha)
@@ -14,83 +15,82 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Set (Set)
 import qualified Data.Set as S
-import GHC.Data.IOEnv (failWithM)
 import GHC.Driver.Session (DynFlags, getDynFlags)
-import GHC.Plugins (
-    CommandLineOption,
+import GHC.Plugins
+  ( CommandLineOption,
     ModSummary,
     Name,
     Plugin (..),
     defaultPlugin,
     localiseName,
     showSDoc,
- )
+  )
 import GHC.Tc.Types (TcGblEnv (..), TcM)
-import GHC.Types.Name.Reader (
-    GlobalRdrElt (..),
+import GHC.Types.Name.Reader
+  ( GlobalRdrElt (..),
     GreName (..),
     ImpDeclSpec (..),
     ImportSpec (..),
- )
+  )
 import GHC.Unit.Module (ModuleName)
 import GHC.Utils.Outputable (Outputable (ppr))
 import Prelude hiding ((<>))
 
 plugin :: Plugin
 plugin =
-    defaultPlugin
-        { typeCheckResultAction = typecheckPlugin
-        }
+  defaultPlugin
+    { typeCheckResultAction = typecheckPlugin
+    }
 
 printPpr :: (Outputable a, MonadIO m) => DynFlags -> a -> m ()
 printPpr dflags = liftIO . putStrLn . showSDoc dflags . ppr
 
 formatName :: DynFlags -> Name -> String
 formatName dflags name =
-    let str = showSDoc dflags . ppr . localiseName $ name
-     in case str of
-            (x : _) ->
-                if isAlpha x
-                    then str
-                    else "(" ++ str ++ ")"
-            _ -> str
+  let str = showSDoc dflags . ppr . localiseName $ name
+   in case str of
+        (x : _) ->
+          if isAlpha x
+            then str
+            else "(" ++ str ++ ")"
+        _ -> str
 
 formatImportedNames :: [String] -> String
 formatImportedNames names =
-    case fmap (++ ",\n") $ sort names of
-        l0 : ls ->
-            let l0' = "  ( " ++ l0
-                ls' = fmap ("    " ++) ls
-                footer = "  )"
-             in concat ([l0'] ++ ls' ++ [footer])
-        _ -> "  ()"
+  case fmap (++ ",\n") $ sort names of
+    l0 : ls ->
+      let l0' = "  ( " ++ l0
+          ls' = fmap ("    " ++) ls
+          footer = "  )"
+       in concat ([l0'] ++ ls' ++ [footer])
+    _ -> "  ()"
 
 mkModuleNameMap :: GlobalRdrElt -> [(ModuleName, Name)]
 mkModuleNameMap gre = do
-    spec <- gre_imp gre
-    case gre_name gre of
-        NormalGreName name -> do
-            let modName = is_mod $ is_decl spec
-            pure (modName, name)
-        _ -> []
+  spec <- gre_imp gre
+  case gre_name gre of
+    NormalGreName name -> do
+      let modName = is_mod $ is_decl spec
+      pure (modName, name)
+    _ -> []
 
 typecheckPlugin ::
-    [CommandLineOption] ->
-    ModSummary ->
-    TcGblEnv ->
-    TcM TcGblEnv
+  [CommandLineOption] ->
+  ModSummary ->
+  TcGblEnv ->
+  TcM TcGblEnv
 typecheckPlugin _ modsummary tc = do
-    dflags <- getDynFlags
-    usedGREs :: [GlobalRdrElt] <-
-        liftIO $ readIORef (tcg_used_gres tc)
-    let moduleImportMap :: Map ModuleName (Set Name)
-        moduleImportMap =
-            foldl' (\(!m) (modu, name) -> M.insertWith S.union modu (S.singleton name) m) M.empty $
-                concatMap mkModuleNameMap usedGREs
-    for_ (M.toList moduleImportMap) $ \(modu, names) -> liftIO $ do
-        putStrLn "---------"
-        printPpr dflags modu
-        let imported = fmap (formatName dflags) $ S.toList names
-        putStrLn $ formatImportedNames imported
-    printPpr dflags modsummary
-    pure tc
+  dflags <- getDynFlags
+  usedGREs :: [GlobalRdrElt] <-
+    liftIO $ readIORef (tcg_used_gres tc)
+  let moduleImportMap :: Map ModuleName (Set Name)
+      moduleImportMap =
+        foldl' (\(!m) (modu, name) -> M.insertWith S.union modu (S.singleton name) m) M.empty $
+          concatMap mkModuleNameMap usedGREs
+  for_ (M.toList moduleImportMap) $ \(modu, names) -> liftIO $ do
+    putStrLn "---------"
+    printPpr dflags modu
+    let imported = fmap (formatName dflags) $ S.toList names
+    putStrLn $ formatImportedNames imported
+  printPpr dflags modsummary
+  pure tc

--- a/src/Plugin/CheckImports.hs
+++ b/src/Plugin/CheckImports.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+-- | CheckImport plugin:
+--   This plugin checks if imported identifiers as unqualified
+--   exist and lists them.
 module Plugin.CheckImports
-  ( plugin,
+  ( -- NOTE: The name "plugin" should be used to be called via GHC plugin mechanism.
+    plugin,
   )
 where
 


### PR DESCRIPTION
Plugin.CheckImports checks unqualified imports in the module which the plugin runs against.
This plugin works only with GHC 9.2. 