### PR TITLE
socket file plugin argument

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -81,6 +81,7 @@ library:
   dependencies:
     - binary
     - containers
+    - directory
     - extra
     - ghc == 9.2.*
     - network
@@ -109,8 +110,9 @@ executables:
       - concur-replica
       - containers
       - ghc-build-analyzer
-      - stm
+      - optparse-applicative
       - replica
+      - stm
 tests:
   ghc-build-analyzer-test:
     main: Spec.hs


### PR DESCRIPTION
No more hard-coded socket file path. Socket file used for comm channel will be explicitly passed via -fplugin-opt