### PR TITLE
Extract module dependency graph from GHC session

### DIFF
--- a/app/toolbox-server/Main.hs
+++ b/app/toolbox-server/Main.hs
@@ -31,6 +31,7 @@ import Toolbox.Channel
     ChanMessageBox (..),
     Channel (..),
     SessionInfo (..),
+    emptyModuleGraphInfo,
   )
 import Toolbox.Comm
   ( receiveObject,
@@ -57,7 +58,9 @@ main :: IO ()
 main = do
   opts <- OA.execParser optsParser
   let socketFile = optSocketFile opts
-  var <- atomically $ newTVar (ServerState 0 mempty (SessionInfo Nothing "") mempty)
+  var <-
+    atomically $
+      newTVar (ServerState 0 mempty (SessionInfo Nothing emptyModuleGraphInfo) mempty)
   _ <- forkIO $ listener socketFile var
   webServer var
 

--- a/app/toolbox-server/Main.hs
+++ b/app/toolbox-server/Main.hs
@@ -57,7 +57,7 @@ main :: IO ()
 main = do
   opts <- OA.execParser optsParser
   let socketFile = optSocketFile opts
-  var <- atomically $ newTVar (ServerState 0 mempty (SessionInfo Nothing) mempty)
+  var <- atomically $ newTVar (ServerState 0 mempty (SessionInfo Nothing "") mempty)
   _ <- forkIO $ listener socketFile var
   webServer var
 

--- a/app/toolbox-server/Main.hs
+++ b/app/toolbox-server/Main.hs
@@ -39,6 +39,7 @@ import Toolbox.Comm
 import Toolbox.Render (render)
 import Toolbox.Server.Types
   ( ServerState (..),
+    Tab (TabCheckImports),
     UIState (..),
     incrementSN,
   )
@@ -86,7 +87,7 @@ webServer :: TVar ServerState -> IO ()
 webServer var = do
   initServerState <- atomically (readTVar var)
   initTime <- getCurrentTime
-  let initUIState = UIState CheckImports Nothing
+  let initUIState = UIState TabCheckImports Nothing
   runDefault 8080 "test" $
     \_ -> loopM step (initUIState, initServerState, initTime)
   where

--- a/app/toolbox-server/Toolbox/Render.hs
+++ b/app/toolbox-server/Toolbox/Render.hs
@@ -28,6 +28,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Replica.VDOM.Types (HTML)
 import Toolbox.Channel (Channel (..))
+import Toolbox.Render.Session (renderSession)
 import Toolbox.Render.Timing (renderTiming)
 import Toolbox.Server.Types
   ( ServerState (..),
@@ -56,6 +57,7 @@ renderInbox (UIState tab mexpandedModu) m =
   ul [] $ map eachRender filtered
   where
     chan = case tab of
+      TabSession -> Session
       TabCheckImports -> CheckImports
       TabTiming -> Timing
     filtered = M.toList $ M.filterWithKey (\(c, _) _ -> chan == c) m
@@ -75,15 +77,11 @@ renderMainPanel ::
   UIState ->
   ServerState ->
   Widget HTML (Maybe Text)
-renderMainPanel ui@(UIState tab mexpandedModu) ss =
+renderMainPanel ui@(UIState tab _) ss =
   case tab of
+    TabSession -> renderSession ss
     TabCheckImports -> renderInbox ui (serverInbox ss)
-    TabTiming ->
-      div
-        []
-        [ pre [] [text $ T.pack $ show (serverSessionInfo ss)]
-        , renderTiming ss
-        ]
+    TabTiming -> renderTiming ss
 
 cssLink :: Text -> Widget HTML a
 cssLink url =
@@ -100,7 +98,8 @@ renderNavbar tab =
     [classList [("navbar", True)]]
     [ navbarMenu
         [ navbarStart
-            [ TabCheckImports <$ navItem (tab == TabCheckImports) [text "CheckImports"]
+            [ TabSession <$ navItem (tab == TabSession) [text "Session"]
+            , TabCheckImports <$ navItem (tab == TabCheckImports) [text "CheckImports"]
             , TabTiming <$ navItem (tab == TabTiming) [text "Timing"]
             ]
         ]

--- a/app/toolbox-server/Toolbox/Render.hs
+++ b/app/toolbox-server/Toolbox/Render.hs
@@ -28,6 +28,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Replica.VDOM.Types (HTML)
 import Toolbox.Channel (Channel (..))
+import Toolbox.Render.ModuleGraph (renderModuleGraph)
 import Toolbox.Render.Session (renderSession)
 import Toolbox.Render.Timing (renderTiming)
 import Toolbox.Server.Types
@@ -58,6 +59,7 @@ renderInbox (UIState tab mexpandedModu) m =
   where
     chan = case tab of
       TabSession -> Session
+      TabModuleGraph -> Session
       TabCheckImports -> CheckImports
       TabTiming -> Timing
     filtered = M.toList $ M.filterWithKey (\(c, _) _ -> chan == c) m
@@ -80,6 +82,7 @@ renderMainPanel ::
 renderMainPanel ui@(UIState tab _) ss =
   case tab of
     TabSession -> renderSession ss
+    TabModuleGraph -> renderModuleGraph ss
     TabCheckImports -> renderInbox ui (serverInbox ss)
     TabTiming -> renderTiming ss
 
@@ -99,6 +102,7 @@ renderNavbar tab =
     [ navbarMenu
         [ navbarStart
             [ TabSession <$ navItem (tab == TabSession) [text "Session"]
+            , TabModuleGraph <$ navItem (tab == TabModuleGraph) [text "Module Graph"]
             , TabCheckImports <$ navItem (tab == TabCheckImports) [text "CheckImports"]
             , TabTiming <$ navItem (tab == TabTiming) [text "Timing"]
             ]

--- a/app/toolbox-server/Toolbox/Render.hs
+++ b/app/toolbox-server/Toolbox/Render.hs
@@ -31,6 +31,7 @@ import Toolbox.Channel (Channel (..))
 import Toolbox.Render.Timing (renderTiming)
 import Toolbox.Server.Types
   ( ServerState (..),
+    Tab (..),
     UIState (..),
     type ChanModule,
     type Inbox,
@@ -50,10 +51,13 @@ iconText ico txt =
         , span [onClick] [text txt]
         ]
 
-renderInbox :: (Channel, Maybe Text) -> Inbox -> Widget HTML (Maybe Text)
-renderInbox (chan, mexpandedModu) m =
+renderInbox :: UIState -> Inbox -> Widget HTML (Maybe Text)
+renderInbox (UIState tab mexpandedModu) m =
   ul [] $ map eachRender filtered
   where
+    chan = case tab of
+      TabCheckImports -> CheckImports
+      TabTiming -> Timing
     filtered = M.toList $ M.filterWithKey (\(c, _) _ -> chan == c) m
 
     eachRender :: (ChanModule, Text) -> Widget HTML (Maybe Text)
@@ -71,17 +75,15 @@ renderMainPanel ::
   UIState ->
   ServerState ->
   Widget HTML (Maybe Text)
-renderMainPanel (UIState chan mexpandedModu) ss =
-  case chan of
-    CheckImports -> renderInbox (CheckImports, mexpandedModu) (serverInbox ss)
-    Timing ->
+renderMainPanel ui@(UIState tab mexpandedModu) ss =
+  case tab of
+    TabCheckImports -> renderInbox ui (serverInbox ss)
+    TabTiming ->
       div
         []
         [ pre [] [text $ T.pack $ show (serverSessionInfo ss)]
-        , div [] [renderTiming ss]
-        -- , renderTiming ss -- renderInbox (Timing, mexpandedModu) (serverInbox ss)
+        , renderTiming ss
         ]
-    _ -> renderInbox (Timing, mexpandedModu) (serverInbox ss)
 
 cssLink :: Text -> Widget HTML a
 cssLink url =
@@ -92,14 +94,14 @@ cssLink url =
     ]
     []
 
-renderNavbar :: Channel -> Widget HTML Channel
-renderNavbar chan =
+renderNavbar :: Tab -> Widget HTML Tab
+renderNavbar tab =
   nav
     [classList [("navbar", True)]]
     [ navbarMenu
         [ navbarStart
-            [ CheckImports <$ navItem (chan == CheckImports) [text "CheckImports"]
-            , Timing <$ navItem (chan == Timing) [text "Timing"]
+            [ TabCheckImports <$ navItem (tab == TabCheckImports) [text "CheckImports"]
+            , TabTiming <$ navItem (tab == TabTiming) [text "Timing"]
             ]
         ]
     ]
@@ -116,7 +118,7 @@ renderNavbar chan =
 render ::
   (UIState, ServerState) ->
   Widget HTML UIState
-render (ui@(UIState chan mexpandedModu), ss) = do
+render (ui@(UIState tab mexpandedModu), ss) = do
   let (mainPanel, bottomPanel)
         | serverMessageSN ss == 0 =
             ( div [] [text "No GHC process yet"]
@@ -135,8 +137,8 @@ render (ui@(UIState chan mexpandedModu), ss) = do
       [classList [("container is-fullheight", True)]]
       [ cssLink "https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
       , cssLink "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.2/css/all.min.css"
-      , (\chan' -> UIState chan' mexpandedModu) <$> renderNavbar chan
-      , (\mexpandedModu' -> UIState chan mexpandedModu') <$> mainPanel
+      , (\tab' -> UIState tab' mexpandedModu) <$> renderNavbar tab
+      , (\mexpandedModu' -> UIState tab mexpandedModu') <$> mainPanel
       , bottomPanel
       ]
   pure ui'

--- a/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
+++ b/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
@@ -75,11 +75,16 @@ formatModuleGraphInfo mgi =
         T.intercalate "\n" . fmap (T.pack . show) $ mginfoModuleNameMap mgi
       txt2 =
         T.intercalate "\n" . fmap (T.pack . show) $ mginfoModuleDep mgi
+      txt3 =
+        T.pack . show $ mginfoModuleTopSorted mgi
    in "(key, module):\n"
         <> txt1
         <> "\n-----------------\n"
         <> "dependencies:\n"
         <> txt2
+        <> "\n-----------------\n"
+        <> "top sorted:\n"
+        <> txt3
         <> "\n=================\n"
         <> analyze mgi
 

--- a/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
+++ b/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Werror #-}
+
+module Toolbox.Render.ModuleGraph
+  ( renderModuleGraph,
+  )
+where
+
+import Concur.Core (Widget)
+import Concur.Replica (div, pre, text)
+import Control.Monad.Extra (loop)
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IM
+import qualified Data.List as L
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Replica.VDOM.Types (HTML)
+import Toolbox.Channel
+  ( ModuleGraphInfo (..),
+    SessionInfo (..),
+  )
+import Toolbox.Server.Types (ServerState (..))
+import Prelude hiding (div)
+
+mkRevDep :: [(Int, [Int])] -> IntMap [Int]
+mkRevDep deps = L.foldl' step emptyMap deps
+  where
+    emptyMap = L.foldl' (\(!acc) (i, _) -> IM.insert i [] acc) IM.empty deps
+    step !acc (i, js) =
+      L.foldl' (\(!acc') j -> IM.insertWith (<>) j [i] acc') acc js
+
+analyze :: ModuleGraphInfo -> Text
+analyze graphInfo =
+  let modDep = mginfoModuleDep graphInfo
+      modRevDepMap = mkRevDep modDep
+      initials = fmap fst $ filter (\(_, js) -> null js) modDep
+      terminals = fmap fst $ filter (\(_, js) -> null js) $ IM.toList modRevDepMap
+      orphans = initials `L.intersect` terminals
+      singles = mapMaybe (\(i, js) -> case js of j : [] -> Just (i, j); _ -> Nothing) modDep
+      leg i = loop go ([i], i)
+        where
+          go (acc', i') =
+            case L.lookup i' singles of
+              Nothing -> Right acc'
+              Just j' -> Left (acc' ++ [j'], j')
+      legs = fmap leg (initials L.\\ orphans)
+   in "intials: " <> (T.pack $ show initials) <> ",\n"
+        <> "terminals: "
+        <> (T.pack $ show terminals)
+        <> ",\n"
+        <> "orphans: "
+        <> (T.pack $ show orphans)
+        <> ",\n"
+        <> "singles: "
+        <> (T.pack $ show singles)
+        <> ",\n"
+        <> "legs: "
+        <> (T.pack $ show legs)
+        <> "\n=============\n"
+        <> (T.pack $ show modRevDepMap)
+
+formatModuleGraphInfo :: ModuleGraphInfo -> Text
+formatModuleGraphInfo mgi =
+  let txt1 =
+        T.intercalate "\n" . fmap (T.pack . show) $ mginfoModuleNameMap mgi
+      txt2 =
+        T.intercalate "\n" . fmap (T.pack . show) $ mginfoModuleDep mgi
+   in "(key, module):\n"
+        <> txt1
+        <> "\n-----------------\n"
+        <> "dependencies:\n"
+        <> txt2
+        <> "\n=================\n"
+        <> analyze mgi
+
+renderModuleGraph :: ServerState -> Widget HTML a
+renderModuleGraph ss =
+  let sessionInfo = serverSessionInfo ss
+   in case sessionStartTime sessionInfo of
+        Nothing ->
+          pre [] [text "GHC Session has not been started"]
+        Just _ ->
+          div
+            []
+            [ pre [] [text $ formatModuleGraphInfo (sessionModuleGraph sessionInfo)]
+            ]
+

--- a/app/toolbox-server/Toolbox/Render/Session.hs
+++ b/app/toolbox-server/Toolbox/Render/Session.hs
@@ -61,18 +61,17 @@ analyze graphInfo =
 
 formatModuleGraphInfo :: ModuleGraphInfo -> Text
 formatModuleGraphInfo mgi =
-  let txt0 = analyze mgi
-      txt1 =
+  let txt1 =
         T.intercalate "\n" . fmap (T.pack . show) $ mginfoModuleNameMap mgi
       txt2 =
         T.intercalate "\n" . fmap (T.pack . show) $ mginfoModuleDep mgi
-   in txt0
-        <> "\n-----------------\n"
-        <> "(key, module):\n"
+   in "(key, module):\n"
         <> txt1
         <> "\n-----------------\n"
         <> "dependencies:\n"
         <> txt2
+        <> "\n=================\n"
+        <> analyze mgi
 
 renderSession :: ServerState -> Widget HTML a
 renderSession ss =

--- a/app/toolbox-server/Toolbox/Render/Session.hs
+++ b/app/toolbox-server/Toolbox/Render/Session.hs
@@ -7,11 +7,27 @@ where
 
 import Concur.Core (Widget)
 import Concur.Replica (div, pre, text)
+import Data.Text (Text)
 import qualified Data.Text as T
 import Replica.VDOM.Types (HTML)
-import Toolbox.Channel (SessionInfo (..))
+import Toolbox.Channel
+  ( ModuleGraphInfo (..),
+    SessionInfo (..),
+  )
 import Toolbox.Server.Types (ServerState (..))
 import Prelude hiding (div)
+
+formatModuleGraphInfo :: ModuleGraphInfo -> Text
+formatModuleGraphInfo mgi =
+  let txt1 =
+        T.intercalate "\n" . fmap (T.pack . show) $ mginfoModuleNameMap mgi
+      txt2 =
+        T.intercalate "\n" . fmap (T.pack . show) $ mginfoModuleDep mgi
+   in "(key, module):\n"
+        <> txt1
+        <> "\n-----------------\n"
+        <> "dependencies:\n"
+        <> txt2
 
 renderSession :: ServerState -> Widget HTML a
 renderSession ss =
@@ -20,9 +36,8 @@ renderSession ss =
         Nothing ->
           pre [] [text "GHC Session has not been started"]
         Just sessionStartTime ->
-          let modGraphTxt = T.pack $ show $ sessionModuleGraph sessionInfo
-           in div
-                []
-                [ pre [] [text $ T.pack $ show sessionStartTime]
-                , pre [] [text modGraphTxt]
-                ]
+          div
+            []
+            [ pre [] [text $ T.pack $ show sessionStartTime]
+            , pre [] [text $ formatModuleGraphInfo (sessionModuleGraph sessionInfo)]
+            ]

--- a/app/toolbox-server/Toolbox/Render/Session.hs
+++ b/app/toolbox-server/Toolbox/Render/Session.hs
@@ -1,0 +1,20 @@
+{-# OPTIONS_GHC -Werror #-}
+
+module Toolbox.Render.Session
+  ( renderSession,
+  )
+where
+
+import Concur.Core (Widget)
+import Concur.Replica (pre, text)
+import qualified Data.Text as T
+import Replica.VDOM.Types (HTML)
+import Toolbox.Channel (SessionInfo (..))
+import Toolbox.Server.Types (ServerState (..))
+
+renderSession :: ServerState -> Widget HTML a
+renderSession ss =
+  case sessionStartTime (serverSessionInfo ss) of
+    Nothing -> pre [] [text "GHC Session has not been started"]
+    Just sessionStartTime ->
+      pre [] [text $ T.pack $ show sessionStartTime]

--- a/app/toolbox-server/Toolbox/Render/Session.hs
+++ b/app/toolbox-server/Toolbox/Render/Session.hs
@@ -20,8 +20,9 @@ renderSession ss =
         Nothing ->
           pre [] [text "GHC Session has not been started"]
         Just sessionStartTime ->
-          div
-            []
-            [ pre [] [text $ T.pack $ show sessionStartTime]
-            , pre [] [text $ sessionModuleGraph sessionInfo]
-            ]
+          let modGraphTxt = T.pack $ show $ sessionModuleGraph sessionInfo
+           in div
+                []
+                [ pre [] [text $ T.pack $ show sessionStartTime]
+                , pre [] [text modGraphTxt]
+                ]

--- a/app/toolbox-server/Toolbox/Render/Session.hs
+++ b/app/toolbox-server/Toolbox/Render/Session.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Werror #-}
 
 module Toolbox.Render.Session
   ( renderSession,
@@ -7,71 +7,11 @@ where
 
 import Concur.Core (Widget)
 import Concur.Replica (div, pre, text)
-import Control.Monad.Extra (loop)
-import Data.IntMap (IntMap)
-import qualified Data.IntMap as IM
-import qualified Data.List as L
-import Data.Maybe (mapMaybe)
-import Data.Text (Text)
 import qualified Data.Text as T
 import Replica.VDOM.Types (HTML)
-import Toolbox.Channel
-  ( ModuleGraphInfo (..),
-    SessionInfo (..),
-  )
+import Toolbox.Channel (SessionInfo (..))
 import Toolbox.Server.Types (ServerState (..))
 import Prelude hiding (div)
-
-mkRevDep :: [(Int, [Int])] -> IntMap [Int]
-mkRevDep deps = L.foldl' step emptyMap deps
-  where
-    emptyMap = L.foldl' (\(!acc) (i, _) -> IM.insert i [] acc) IM.empty deps
-    step !acc (i, js) =
-      L.foldl' (\(!acc') j -> IM.insertWith (<>) j [i] acc') acc js
-
-analyze :: ModuleGraphInfo -> Text
-analyze graphInfo =
-  let modDep = mginfoModuleDep graphInfo
-      modRevDepMap = mkRevDep modDep
-      initials = fmap fst $ filter (\(_, js) -> null js) modDep
-      terminals = fmap fst $ filter (\(_, js) -> null js) $ IM.toList modRevDepMap
-      orphans = initials `L.intersect` terminals
-      singles = mapMaybe (\(i, js) -> case js of j : [] -> Just (i, j); _ -> Nothing) modDep
-      leg i = loop go ([i], i)
-        where
-          go (acc', i') =
-            case L.lookup i' singles of
-              Nothing -> Right acc'
-              Just j' -> Left (acc' ++ [j'], j')
-      legs = fmap leg (initials L.\\ orphans)
-   in "intials: " <> (T.pack $ show initials) <> ",\n"
-        <> "terminals: "
-        <> (T.pack $ show terminals)
-        <> ",\n"
-        <> "orphans: "
-        <> (T.pack $ show orphans)
-        <> ",\n"
-        <> "singles: "
-        <> (T.pack $ show singles)
-        <> ",\n"
-        <> "legs: "
-        <> (T.pack $ show legs)
-        <> "\n=============\n"
-        <> (T.pack $ show modRevDepMap)
-
-formatModuleGraphInfo :: ModuleGraphInfo -> Text
-formatModuleGraphInfo mgi =
-  let txt1 =
-        T.intercalate "\n" . fmap (T.pack . show) $ mginfoModuleNameMap mgi
-      txt2 =
-        T.intercalate "\n" . fmap (T.pack . show) $ mginfoModuleDep mgi
-   in "(key, module):\n"
-        <> txt1
-        <> "\n-----------------\n"
-        <> "dependencies:\n"
-        <> txt2
-        <> "\n=================\n"
-        <> analyze mgi
 
 renderSession :: ServerState -> Widget HTML a
 renderSession ss =
@@ -83,5 +23,4 @@ renderSession ss =
           div
             []
             [ pre [] [text $ T.pack $ show sessionStartTime]
-            , pre [] [text $ formatModuleGraphInfo (sessionModuleGraph sessionInfo)]
             ]

--- a/app/toolbox-server/Toolbox/Render/Session.hs
+++ b/app/toolbox-server/Toolbox/Render/Session.hs
@@ -7,9 +7,11 @@ where
 
 import Concur.Core (Widget)
 import Concur.Replica (div, pre, text)
+import Control.Monad.Extra (loop)
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IM
-import Data.List (foldl')
+import qualified Data.List as L
+import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Replica.VDOM.Types (HTML)
@@ -21,21 +23,41 @@ import Toolbox.Server.Types (ServerState (..))
 import Prelude hiding (div)
 
 mkRevDep :: [(Int, [Int])] -> IntMap [Int]
-mkRevDep = foldl' step IM.empty
+mkRevDep deps = L.foldl' step emptyMap deps
   where
+    emptyMap = L.foldl' (\(!acc) (i, _) -> IM.insert i [] acc) IM.empty deps
     step !acc (i, js) =
-      foldl' (\(!acc') j -> IM.insertWith (<>) j [i] acc') acc js
+      L.foldl' (\(!acc') j -> IM.insertWith (<>) j [i] acc') acc js
 
 analyze :: ModuleGraphInfo -> Text
 analyze graphInfo =
   let modDep = mginfoModuleDep graphInfo
-      revDepMap = mkRevDep modDep
-      orphans = filter (\(_, js) -> null js) modDep
-      nOrphans = length orphans
-      nSingle = length $ filter (\(_, js) -> length js == 1) modDep
-   in (T.pack $ show nOrphans) <> ", " <> (T.pack $ show nSingle)
+      modRevDepMap = mkRevDep modDep
+      initials = fmap fst $ filter (\(_, js) -> null js) modDep
+      terminals = fmap fst $ filter (\(_, js) -> null js) $ IM.toList modRevDepMap
+      orphans = initials `L.intersect` terminals
+      singles = mapMaybe (\(i, js) -> case js of j : [] -> Just (i, j); _ -> Nothing) modDep
+      leg i = loop go ([i], i)
+        where
+          go (acc', i') =
+            case L.lookup i' singles of
+              Nothing -> Right acc'
+              Just j' -> Left (acc' ++ [j'], j')
+      legs = fmap leg (initials L.\\ orphans)
+   in "intials: " <> (T.pack $ show initials) <> ",\n"
+        <> "terminals: "
+        <> (T.pack $ show terminals)
+        <> ",\n"
+        <> "orphans: "
+        <> (T.pack $ show orphans)
+        <> ",\n"
+        <> "singles: "
+        <> (T.pack $ show singles)
+        <> ",\n"
+        <> "legs: "
+        <> (T.pack $ show legs)
         <> "\n=============\n"
-        <> (T.pack $ show revDepMap)
+        <> (T.pack $ show modRevDepMap)
 
 formatModuleGraphInfo :: ModuleGraphInfo -> Text
 formatModuleGraphInfo mgi =

--- a/app/toolbox-server/Toolbox/Render/Session.hs
+++ b/app/toolbox-server/Toolbox/Render/Session.hs
@@ -6,15 +6,22 @@ module Toolbox.Render.Session
 where
 
 import Concur.Core (Widget)
-import Concur.Replica (pre, text)
+import Concur.Replica (div, pre, text)
 import qualified Data.Text as T
 import Replica.VDOM.Types (HTML)
 import Toolbox.Channel (SessionInfo (..))
 import Toolbox.Server.Types (ServerState (..))
+import Prelude hiding (div)
 
 renderSession :: ServerState -> Widget HTML a
 renderSession ss =
-  case sessionStartTime (serverSessionInfo ss) of
-    Nothing -> pre [] [text "GHC Session has not been started"]
-    Just sessionStartTime ->
-      pre [] [text $ T.pack $ show sessionStartTime]
+  let sessionInfo = serverSessionInfo ss
+   in case sessionStartTime sessionInfo of
+        Nothing ->
+          pre [] [text "GHC Session has not been started"]
+        Just sessionStartTime ->
+          div
+            []
+            [ pre [] [text $ T.pack $ show sessionStartTime]
+            , pre [] [text $ sessionModuleGraph sessionInfo]
+            ]

--- a/app/toolbox-server/Toolbox/Render/Session.hs
+++ b/app/toolbox-server/Toolbox/Render/Session.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Werror #-}
+{-# LANGUAGE BangPatterns #-}
 
 module Toolbox.Render.Session
   ( renderSession,
@@ -7,6 +7,9 @@ where
 
 import Concur.Core (Widget)
 import Concur.Replica (div, pre, text)
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IM
+import Data.List (foldl')
 import Data.Text (Text)
 import qualified Data.Text as T
 import Replica.VDOM.Types (HTML)
@@ -17,13 +20,33 @@ import Toolbox.Channel
 import Toolbox.Server.Types (ServerState (..))
 import Prelude hiding (div)
 
+mkRevDep :: [(Int, [Int])] -> IntMap [Int]
+mkRevDep = foldl' step IM.empty
+  where
+    step !acc (i, js) =
+      foldl' (\(!acc') j -> IM.insertWith (<>) j [i] acc') acc js
+
+analyze :: ModuleGraphInfo -> Text
+analyze graphInfo =
+  let modDep = mginfoModuleDep graphInfo
+      revDepMap = mkRevDep modDep
+      orphans = filter (\(_, js) -> null js) modDep
+      nOrphans = length orphans
+      nSingle = length $ filter (\(_, js) -> length js == 1) modDep
+   in (T.pack $ show nOrphans) <> ", " <> (T.pack $ show nSingle)
+        <> "\n=============\n"
+        <> (T.pack $ show revDepMap)
+
 formatModuleGraphInfo :: ModuleGraphInfo -> Text
 formatModuleGraphInfo mgi =
-  let txt1 =
+  let txt0 = analyze mgi
+      txt1 =
         T.intercalate "\n" . fmap (T.pack . show) $ mginfoModuleNameMap mgi
       txt2 =
         T.intercalate "\n" . fmap (T.pack . show) $ mginfoModuleDep mgi
-   in "(key, module):\n"
+   in txt0
+        <> "\n-----------------\n"
+        <> "(key, module):\n"
         <> txt1
         <> "\n-----------------\n"
         <> "dependencies:\n"

--- a/app/toolbox-server/Toolbox/Server/Types.hs
+++ b/app/toolbox-server/Toolbox/Server/Types.hs
@@ -16,7 +16,7 @@ type ChanModule = (Channel, Text)
 
 type Inbox = Map ChanModule Text
 
-data Tab = TabCheckImports | TabTiming
+data Tab = TabSession | TabCheckImports | TabTiming
   deriving (Eq)
 
 data UIState = UIState

--- a/app/toolbox-server/Toolbox/Server/Types.hs
+++ b/app/toolbox-server/Toolbox/Server/Types.hs
@@ -1,6 +1,7 @@
 module Toolbox.Server.Types
   ( type ChanModule,
     type Inbox,
+    Tab (..),
     UIState (..),
     ServerState (..),
     incrementSN,
@@ -15,8 +16,11 @@ type ChanModule = (Channel, Text)
 
 type Inbox = Map ChanModule Text
 
+data Tab = TabCheckImports | TabTiming
+  deriving (Eq)
+
 data UIState = UIState
-  { uiTab :: Channel
+  { uiTab :: Tab
   , uiModule :: Maybe Text
   }
 

--- a/app/toolbox-server/Toolbox/Server/Types.hs
+++ b/app/toolbox-server/Toolbox/Server/Types.hs
@@ -16,7 +16,7 @@ type ChanModule = (Channel, Text)
 
 type Inbox = Map ChanModule Text
 
-data Tab = TabSession | TabCheckImports | TabTiming
+data Tab = TabSession | TabModuleGraph | TabCheckImports | TabTiming
   deriving (Eq)
 
 data UIState = UIState

--- a/examples/timing/C.hs
+++ b/examples/timing/C.hs
@@ -1,0 +1,10 @@
+{-# OPTIONS_GHC -fplugin Plugin.CheckImports -fplugin Plugin.Timing #-}
+module C (test3) where
+
+import A (test)
+import B (test2)
+
+test3 :: IO ()
+test3 = do
+  test
+  test2

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
           p.cabal-install
           p.concur-core
           p.concur-replica
+          p.discrimination
           p.extra
           p.fourmolu
           p.hpack

--- a/package.yaml
+++ b/package.yaml
@@ -111,6 +111,7 @@ executables:
       - concur-core
       - concur-replica
       - containers
+      - discrimination
       - extra
       - ghc-build-analyzer
       - optparse-applicative

--- a/src/Toolbox/Channel.hs
+++ b/src/Toolbox/Channel.hs
@@ -25,21 +25,22 @@ data Channel = CheckImports | Timing | Session
 type ModuleName = Text
 
 data ModuleGraphInfo = ModuleGraphInfo
-  { mginfoModuleNameMap :: [(Int, Text)]
+  { mginfoModuleNameMap :: [(Int, ModuleName)]
   , mginfoModuleDep :: [(Int, [Int])]
+  , mginfoModuleTopSorted :: [Int]
   }
   deriving (Show)
 
 instance Binary ModuleGraphInfo where
-  put (ModuleGraphInfo m d) = put (m, d)
-  get = uncurry ModuleGraphInfo <$> get
+  put (ModuleGraphInfo m d s) = put (m, d, s)
+  get = (\(m, d, s) -> ModuleGraphInfo m d s) <$> get
 
 emptyModuleGraphInfo :: ModuleGraphInfo
-emptyModuleGraphInfo = ModuleGraphInfo [] []
+emptyModuleGraphInfo = ModuleGraphInfo [] [] []
 
 data SessionInfo = SessionInfo
   { sessionStartTime :: Maybe UTCTime
-  , sessionModuleGraph :: ModuleGraphInfo -- Text
+  , sessionModuleGraph :: ModuleGraphInfo
   }
   deriving (Show)
 

--- a/src/Toolbox/Channel.hs
+++ b/src/Toolbox/Channel.hs
@@ -10,6 +10,7 @@ module Toolbox.Channel
     Timer (..),
     resetTimer,
     ModuleGraphInfo (..),
+    emptyModuleGraphInfo,
   )
 where
 
@@ -29,9 +30,16 @@ data ModuleGraphInfo = ModuleGraphInfo
   }
   deriving (Show)
 
+instance Binary ModuleGraphInfo where
+  put (ModuleGraphInfo m d) = put (m, d)
+  get = uncurry ModuleGraphInfo <$> get
+
+emptyModuleGraphInfo :: ModuleGraphInfo
+emptyModuleGraphInfo = ModuleGraphInfo [] []
+
 data SessionInfo = SessionInfo
   { sessionStartTime :: Maybe UTCTime
-  , sessionModuleGraph :: Text
+  , sessionModuleGraph :: ModuleGraphInfo -- Text
   }
   deriving (Show)
 

--- a/src/Toolbox/Channel.hs
+++ b/src/Toolbox/Channel.hs
@@ -22,9 +22,15 @@ data Channel = CheckImports | Timing | Session
 
 type ModuleName = Text
 
-newtype SessionInfo = SessionInfo
-  {sessionStartTime :: Maybe UTCTime}
-  deriving (Show, Binary)
+data SessionInfo = SessionInfo
+  { sessionStartTime :: Maybe UTCTime
+  , sessionModuleGraph :: Text
+  }
+  deriving (Show)
+
+instance Binary SessionInfo where
+  put (SessionInfo mtime modGraph) = put (mtime, modGraph)
+  get = uncurry SessionInfo <$> get
 
 data Timer = Timer
   { timerStart :: Maybe UTCTime

--- a/src/Toolbox/Channel.hs
+++ b/src/Toolbox/Channel.hs
@@ -9,6 +9,7 @@ module Toolbox.Channel
     SessionInfo (..),
     Timer (..),
     resetTimer,
+    ModuleGraphInfo (..),
   )
 where
 
@@ -21,6 +22,12 @@ data Channel = CheckImports | Timing | Session
   deriving (Enum, Eq, Ord, Show)
 
 type ModuleName = Text
+
+data ModuleGraphInfo = ModuleGraphInfo
+  { mginfoModuleNameMap :: [(Int, Text)]
+  , mginfoModuleDep :: [(Int, [Int])]
+  }
+  deriving (Show)
 
 data SessionInfo = SessionInfo
   { sessionStartTime :: Maybe UTCTime


### PR DESCRIPTION
ModuleGraph data structure is extracted from GHC session and converted to a simplified graph data structure, which is sent to display daemon.
