### PR TITLE
Dynamic module graph generation and progress bar

### DIFF
--- a/app/toolbox-server/Main.hs
+++ b/app/toolbox-server/Main.hs
@@ -61,7 +61,7 @@ main = do
   let socketFile = optSocketFile opts
   var <-
     atomically $
-      newTVar (ServerState 0 mempty (SessionInfo Nothing emptyModuleGraphInfo) mempty Nothing)
+      newTVar (ServerState 0 mempty (SessionInfo Nothing emptyModuleGraphInfo) mempty Nothing [])
   _ <- forkIO $ listener socketFile var
   webServer var
 

--- a/app/toolbox-server/Main.hs
+++ b/app/toolbox-server/Main.hs
@@ -30,7 +30,6 @@ import Toolbox.Channel
   ( ChanMessage (..),
     ChanMessageBox (..),
     Channel (..),
-    ModuleGraphInfo (..),
     SessionInfo (..),
     emptyModuleGraphInfo,
   )
@@ -39,17 +38,13 @@ import Toolbox.Comm
     runServer,
   )
 import Toolbox.Render (render)
-import Toolbox.Render.ModuleGraph
-  ( layOutGraph,
-    makeReducedGraphReversedFromModuleGraph,
-  )
 import Toolbox.Server.Types
-  ( GraphVisInfo (..),
-    ServerState (..),
+  ( ServerState (..),
     Tab (TabCheckImports),
     UIState (..),
     incrementSN,
   )
+import Toolbox.Worker (moduleGraphWorker)
 import Prelude hiding (div)
 
 newtype Options = Options {optSocketFile :: FilePath}
@@ -72,17 +67,6 @@ main = do
 
 updateInterval :: NominalDiffTime
 updateInterval = secondsToNominalDiffTime (fromRational (1 / 2))
-
-moduleGraphWorker :: TVar ServerState -> ModuleGraphInfo -> IO ()
-moduleGraphWorker var graphInfo = do
-  let modNameMap = mginfoModuleNameMap graphInfo
-      reducedGraphReversed =
-        makeReducedGraphReversedFromModuleGraph graphInfo
-  grVisInfo <- layOutGraph modNameMap reducedGraphReversed
-  putStrLn $ "number of boxes : " ++ show (length (gviNodes grVisInfo))
-  print grVisInfo
-  atomically $
-    modifyTVar' var (\ss -> incrementSN (ss {serverModuleGraph = Just grVisInfo}))
 
 listener :: FilePath -> TVar ServerState -> IO ()
 listener socketFile var =

--- a/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
+++ b/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
@@ -55,7 +55,10 @@ import Toolbox.Channel
     Timer,
   )
 import Toolbox.Server.Types
-  ( GraphVisInfo (..),
+  ( Dimension (..),
+    EdgeLayout (..),
+    GraphVisInfo (..),
+    Point (..),
     NodeLayout (..),
     ServerState (..),
   )
@@ -148,10 +151,10 @@ formatModuleGraphInfo mgi =
         <> ", # of edges: "
         <> T.pack (show nEdg)
 
-makePolylineText :: [(Double, Double)] -> Text
+makePolylineText :: [Point] -> Text
 makePolylineText xys = T.intercalate " " (fmap each xys)
   where
-    each (x, y) = [fmt|{x:.2},{y:.2}|]
+    each (Point x y) = [fmt|{x:.2},{y:.2}|]
 
 renderModuleGraphSVG ::
   Map Text Timer ->
@@ -159,8 +162,8 @@ renderModuleGraphSVG ::
   GraphVisInfo ->
   Widget HTML a
 renderModuleGraphSVG timing clustering grVisInfo =
-  let (canvasWidth, canvasHeight) = gviCanvasDim grVisInfo
-      edge (_, _, xys) =
+  let Dim canvasWidth canvasHeight = gviCanvasDim grVisInfo
+      edge (EdgeLayout _ _ xys) =
         S.polyline
           [ SP.points (makePolylineText xys)
           , SP.stroke "gray"
@@ -170,7 +173,7 @@ renderModuleGraphSVG timing clustering grVisInfo =
       aFactor = 0.8
       offXFactor = -0.4
       offYFactor = -0.6
-      box0 (_, x, y, w, h) =
+      box0 (NodeLayout _ (Point x y) (Dim w h)) =
         S.rect
           [ SP.x (T.pack $ show (x + w * offXFactor))
           , SP.y (T.pack $ show (y + h * offYFactor + h - 12))
@@ -180,7 +183,7 @@ renderModuleGraphSVG timing clustering grVisInfo =
           , SP.fill "ivory"
           ]
           []
-      box1 (_, x, y, w, h) =
+      box1 (NodeLayout _ (Point x y) (Dim w h)) =
         S.rect
           [ SP.x (T.pack $ show (x + w * offXFactor))
           , SP.y (T.pack $ show (y + h * offYFactor + h + 3))
@@ -190,7 +193,7 @@ renderModuleGraphSVG timing clustering grVisInfo =
           , SP.fill "none"
           ]
           []
-      box2 (name, x, y, w, h) =
+      box2 (NodeLayout name (Point x y) (Dim w h)) =
         let ratio = fromMaybe 0 $ do
               cluster <- L.lookup name clustering
               let nTot = length cluster
@@ -209,7 +212,7 @@ renderModuleGraphSVG timing clustering grVisInfo =
               , SP.fill "blue"
               ]
               []
-      moduleText (name, x, y, w, h) =
+      moduleText (NodeLayout name (Point x y) (Dim w h)) =
         S.text
           [ SP.x (T.pack $ show (x + w * offXFactor))
           , SP.y (T.pack $ show (y + h * offYFactor + h))

--- a/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
+++ b/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
@@ -176,8 +176,8 @@ renderModuleGraphSVG timing clustering grVisInfo =
           , SP.y (T.pack $ show (y + h * offYFactor + h - 12))
           , width (T.pack $ show (w * aFactor))
           , height "20"
-          , SP.stroke "gray"
-          , SP.fill "white"
+          , SP.stroke "dimgray"
+          , SP.fill "ivory"
           ]
           []
       box1 (_, x, y, w, h) =
@@ -206,7 +206,7 @@ renderModuleGraphSVG timing clustering grVisInfo =
               , SP.y (T.pack $ show (y + h * offYFactor + h + 3))
               , width (T.pack $ show (w' * aFactor))
               , height "5"
-              , SP.fill "green"
+              , SP.fill "blue"
               ]
               []
       moduleText (name, x, y, w, h) =

--- a/app/toolbox-server/Toolbox/Render/Session.hs
+++ b/app/toolbox-server/Toolbox/Render/Session.hs
@@ -7,6 +7,7 @@ where
 
 import Concur.Core (Widget)
 import Concur.Replica (div, pre, text)
+import qualified Data.Map as M
 import qualified Data.Text as T
 import Replica.VDOM.Types (HTML)
 import Toolbox.Channel (SessionInfo (..))
@@ -16,6 +17,8 @@ import Prelude hiding (div)
 renderSession :: ServerState -> Widget HTML a
 renderSession ss =
   let sessionInfo = serverSessionInfo ss
+      timing = serverTiming ss
+      msg = "# of compiled module now : " <> T.pack (show (M.size timing))
    in case sessionStartTime sessionInfo of
         Nothing ->
           pre [] [text "GHC Session has not been started"]
@@ -23,4 +26,5 @@ renderSession ss =
           div
             []
             [ pre [] [text $ T.pack $ show sessionStartTime]
+            , pre [] [text msg]
             ]

--- a/app/toolbox-server/Toolbox/Render/Timing.hs
+++ b/app/toolbox-server/Toolbox/Render/Timing.hs
@@ -96,9 +96,7 @@ renderTimingChart timingInfos =
                 ++ (concatMap (\x -> [box x, moduleText x]) $ zip [0 ..] timingInfos)
             )
           )
-      infoElement =
-        pre [] [text "text"]
-   in div [] [svgElement, infoElement]
+   in div [] [svgElement]
 
 renderTiming :: ServerState -> Widget HTML a
 renderTiming ss =

--- a/app/toolbox-server/Toolbox/Server/Types.hs
+++ b/app/toolbox-server/Toolbox/Server/Types.hs
@@ -17,7 +17,12 @@ where
 
 import Data.Map.Strict (Map)
 import Data.Text (Text)
-import Toolbox.Channel (Channel, SessionInfo, Timer)
+import Toolbox.Channel
+  ( Channel,
+    SessionInfo,
+    Timer,
+    type ModuleName,
+  )
 
 type ChanModule = (Channel, Text)
 
@@ -72,8 +77,9 @@ data ServerState = ServerState
   { serverMessageSN :: Int
   , serverInbox :: Inbox
   , serverSessionInfo :: SessionInfo
-  , serverTiming :: Map Text Timer
+  , serverTiming :: Map ModuleName Timer
   , serverModuleGraph :: Maybe GraphVisInfo
+  , serverModuleClustering :: [(ModuleName, [ModuleName])]
   }
 
 incrementSN :: ServerState -> ServerState

--- a/app/toolbox-server/Toolbox/Server/Types.hs
+++ b/app/toolbox-server/Toolbox/Server/Types.hs
@@ -61,6 +61,8 @@ data NodeLayout a = NodeLayout
 data EdgeLayout = EdgeLayout
   { edgeId :: Int
   -- ^ edge id from the graph layouter
+  , edgeEndNodes :: (Int, Int)
+  -- ^ (source node, target node)
   , edgePoints :: [Point]
   -- ^ edge start point, bend points, end point
   }

--- a/app/toolbox-server/Toolbox/Server/Types.hs
+++ b/app/toolbox-server/Toolbox/Server/Types.hs
@@ -73,6 +73,7 @@ data ServerState = ServerState
   , serverInbox :: Inbox
   , serverSessionInfo :: SessionInfo
   , serverTiming :: Map Text Timer
+  , serverModuleGraph :: Maybe GraphVisInfo
   }
 
 incrementSN :: ServerState -> ServerState

--- a/app/toolbox-server/Toolbox/Util/OGDF.hs
+++ b/app/toolbox-server/Toolbox/Util/OGDF.hs
@@ -63,7 +63,9 @@ import OGDF.DRect (dRect_height, dRect_width)
 import OGDF.EdgeElement
   ( EdgeElement (..),
     edgeElement_index,
+    edgeElement_source,
     edgeElement_succ,
+    edgeElement_target,
   )
 import OGDF.Graph
   ( Graph,
@@ -277,6 +279,14 @@ getAllEdgeLayout g ga = do
       then pure (Right acc)
       else do
         j :: Int <- fromIntegral <$> liftIO (edgeElement_index e)
+        src <- liftIO (edgeElement_source e)
+        isrc <- fromIntegral <$> liftIO (nodeElement_index src)
+        srcX <- getNodeX ga src
+        srcY <- getNodeY ga src
+        tgt <- liftIO (edgeElement_target e)
+        itgt <- fromIntegral <$> liftIO (nodeElement_index tgt)
+        tgtX <- getNodeX ga tgt
+        tgtY <- getNodeY ga tgt
         dpline <- liftIO (graphAttributes_bends ga e)
         it0 <- liftIO (begin dpline)
         bendPoints <-
@@ -291,7 +301,8 @@ getAllEdgeLayout g ga = do
                   (Left . (bpts',) <$> liftIO (listIteratorSucc it))
               )
               (pure $ Right bpts)
-        let acc' = acc ++ [EdgeLayout j bendPoints]
+        let pts = [(srcX, srcY)] ++ bendPoints ++ [(tgtX, tgtY)]
+        let acc' = acc ++ [EdgeLayout j (isrc, itgt) pts)]
         Left . (acc',) <$> liftIO (edgeElement_succ e)
 
 doSugiyamaLayout :: GraphAttributes -> GraphLayouter ()

--- a/app/toolbox-server/Toolbox/Util/OGDF.hs
+++ b/app/toolbox-server/Toolbox/Util/OGDF.hs
@@ -301,8 +301,8 @@ getAllEdgeLayout g ga = do
                   (Left . (bpts',) <$> liftIO (listIteratorSucc it))
               )
               (pure $ Right bpts)
-        let pts = [(srcX, srcY)] ++ bendPoints ++ [(tgtX, tgtY)]
-        let acc' = acc ++ [EdgeLayout j (isrc, itgt) pts)]
+        let pts = [Point srcX srcY] ++ bendPoints ++ [Point tgtX tgtY]
+        let acc' = acc ++ [EdgeLayout j (isrc, itgt) pts]
         Left . (acc',) <$> liftIO (edgeElement_succ e)
 
 doSugiyamaLayout :: GraphAttributes -> GraphLayouter ()

--- a/app/toolbox-server/Toolbox/Worker.hs
+++ b/app/toolbox-server/Toolbox/Worker.hs
@@ -4,20 +4,50 @@ module Toolbox.Worker
 where
 
 import Control.Concurrent.STM (TVar, atomically, modifyTVar')
+import qualified Data.IntMap as IM
+import qualified Data.List as L
+import Data.Maybe (mapMaybe)
 import Toolbox.Channel (ModuleGraphInfo (..))
 import Toolbox.Render.ModuleGraph (layOutGraph)
 import Toolbox.Server.Types
-  ( GraphVisInfo (..),
-    ServerState (..),
+  ( ServerState (..),
     incrementSN,
   )
-import Toolbox.Util.Graph (makeReducedGraphReversedFromModuleGraph)
+import Toolbox.Util.Graph
+  ( ClusterState (..),
+    ClusterVertex (..),
+    fullStep,
+    getBiDepGraph,
+    makeReducedGraphReversedFromModuleGraph,
+    makeSeedState,
+  )
 
 moduleGraphWorker :: TVar ServerState -> ModuleGraphInfo -> IO ()
-moduleGraphWorker var graphInfo = do
-  let modNameMap = mginfoModuleNameMap graphInfo
+moduleGraphWorker var mgi = do
+  let modNameMap = mginfoModuleNameMap mgi
       reducedGraphReversed =
-        makeReducedGraphReversedFromModuleGraph graphInfo
+        makeReducedGraphReversedFromModuleGraph mgi
   grVisInfo <- layOutGraph modNameMap reducedGraphReversed
+  let allNodes = IM.keys modNameMap
+      largeNodes = IM.keys reducedGraphReversed
+      smallNodes = allNodes L.\\ largeNodes
+      seedClustering =
+        ClusterState
+          { clusterStateClustered = fmap (\i -> (Cluster i, [i])) largeNodes
+          , clusterStateUnclustered = smallNodes
+          }
+      bgr = getBiDepGraph mgi
+      (clustering, _) = fullStep (seedClustering, makeSeedState largeNodes bgr)
+      clusteringFinal = mapMaybe convert (clusterStateClustered clustering)
+        where
+          convert (Cluster i, js) = do
+            clusterName <- IM.lookup i modNameMap
+            let members = mapMaybe (\j -> IM.lookup j modNameMap) js
+            pure (clusterName, members)
   atomically $
-    modifyTVar' var (\ss -> incrementSN (ss {serverModuleGraph = Just grVisInfo}))
+    modifyTVar' var $ \ss ->
+      incrementSN $
+        ss
+          { serverModuleGraph = Just grVisInfo
+          , serverModuleClustering = clusteringFinal
+          }

--- a/app/toolbox-server/Toolbox/Worker.hs
+++ b/app/toolbox-server/Toolbox/Worker.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module Toolbox.Worker
   ( moduleGraphWorker,
   )

--- a/app/toolbox-server/Toolbox/Worker.hs
+++ b/app/toolbox-server/Toolbox/Worker.hs
@@ -5,15 +5,13 @@ where
 
 import Control.Concurrent.STM (TVar, atomically, modifyTVar')
 import Toolbox.Channel (ModuleGraphInfo (..))
-import Toolbox.Render.ModuleGraph
-  ( layOutGraph,
-    makeReducedGraphReversedFromModuleGraph,
-  )
+import Toolbox.Render.ModuleGraph (layOutGraph)
 import Toolbox.Server.Types
   ( GraphVisInfo (..),
     ServerState (..),
     incrementSN,
   )
+import Toolbox.Util.Graph (makeReducedGraphReversedFromModuleGraph)
 
 moduleGraphWorker :: TVar ServerState -> ModuleGraphInfo -> IO ()
 moduleGraphWorker var graphInfo = do
@@ -21,7 +19,5 @@ moduleGraphWorker var graphInfo = do
       reducedGraphReversed =
         makeReducedGraphReversedFromModuleGraph graphInfo
   grVisInfo <- layOutGraph modNameMap reducedGraphReversed
-  putStrLn $ "number of boxes : " ++ show (length (gviNodes grVisInfo))
-  print grVisInfo
   atomically $
     modifyTVar' var (\ss -> incrementSN (ss {serverModuleGraph = Just grVisInfo}))

--- a/app/toolbox-server/Toolbox/Worker.hs
+++ b/app/toolbox-server/Toolbox/Worker.hs
@@ -1,0 +1,27 @@
+module Toolbox.Worker
+  ( moduleGraphWorker,
+  )
+where
+
+import Control.Concurrent.STM (TVar, atomically, modifyTVar')
+import Toolbox.Channel (ModuleGraphInfo (..))
+import Toolbox.Render.ModuleGraph
+  ( layOutGraph,
+    makeReducedGraphReversedFromModuleGraph,
+  )
+import Toolbox.Server.Types
+  ( GraphVisInfo (..),
+    ServerState (..),
+    incrementSN,
+  )
+
+moduleGraphWorker :: TVar ServerState -> ModuleGraphInfo -> IO ()
+moduleGraphWorker var graphInfo = do
+  let modNameMap = mginfoModuleNameMap graphInfo
+      reducedGraphReversed =
+        makeReducedGraphReversedFromModuleGraph graphInfo
+  grVisInfo <- layOutGraph modNameMap reducedGraphReversed
+  putStrLn $ "number of boxes : " ++ show (length (gviNodes grVisInfo))
+  print grVisInfo
+  atomically $
+    modifyTVar' var (\ss -> incrementSN (ss {serverModuleGraph = Just grVisInfo}))

--- a/src/Plugin/Timing.hs
+++ b/src/Plugin/Timing.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 
--- This module provides the current module under compilation..
+-- This module provides the current module under compilation.
 module Plugin.Timing
   ( -- NOTE: The name "plugin" should be used as a GHC plugin.
     plugin,

--- a/src/Plugin/Timing.hs
+++ b/src/Plugin/Timing.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 
--- This module provides the current module under compilation.
+-- This module provides the current module under compilation..
 module Plugin.Timing
   ( -- NOTE: The name "plugin" should be used as a GHC plugin.
     plugin,


### PR DESCRIPTION
With the generated module graph layout, dynamic concur-replica SVG components are generated. 
I also added a simple progress bar below the module label to display the current build status in terms of # of compiled modules inside the cluster.