### PR TITLE
Show module  dep subgraph in the selected module cluster

### DIFF
--- a/app/toolbox-server/Main.hs
+++ b/app/toolbox-server/Main.hs
@@ -40,7 +40,7 @@ import Toolbox.Comm
 import Toolbox.Render (render)
 import Toolbox.Server.Types
   ( ServerState (..),
-    Tab (TabCheckImports),
+    Tab (TabSession),
     UIState (..),
     incrementSN,
   )
@@ -99,7 +99,7 @@ webServer :: TVar ServerState -> IO ()
 webServer var = do
   initServerState <- atomically (readTVar var)
   initTime <- getCurrentTime
-  let initUIState = UIState TabCheckImports Nothing
+  let initUIState = UIState TabSession Nothing Nothing
   runDefault 8080 "test" $
     \_ -> loopM step (initUIState, initServerState, initTime)
   where

--- a/app/toolbox-server/Main.hs
+++ b/app/toolbox-server/Main.hs
@@ -40,9 +40,8 @@ import Toolbox.Comm
 import Toolbox.Render (render)
 import Toolbox.Server.Types
   ( ServerState (..),
-    Tab (TabSession),
-    UIState (..),
     incrementSN,
+    initUIState,
   )
 import Toolbox.Worker (moduleGraphWorker)
 import Prelude hiding (div)
@@ -99,7 +98,6 @@ webServer :: TVar ServerState -> IO ()
 webServer var = do
   initServerState <- atomically (readTVar var)
   initTime <- getCurrentTime
-  let initUIState = UIState TabSession Nothing Nothing
   runDefault 8080 "test" $
     \_ -> loopM step (initUIState, initServerState, initTime)
   where

--- a/app/toolbox-server/Toolbox/Render.hs
+++ b/app/toolbox-server/Toolbox/Render.hs
@@ -103,7 +103,7 @@ cssLink url =
 renderNavbar :: Tab -> Widget HTML Event
 renderNavbar tab =
   nav
-    [classList [("navbar", True)]]
+    [classList [("navbar m-0 p-0", True)]]
     [ navbarMenu
         [ navbarStart
             [ TabEv TabSession <$ navItem (tab == TabSession) [text "Session"]
@@ -118,8 +118,8 @@ renderNavbar tab =
     navbarStart = divClass "navbar-start" []
     navItem isActive =
       let clss
-            | isActive = ["navbar-item", "is-tab", "is-active"]
-            | otherwise = ["navbar-item", "is-tab"]
+            | isActive = ["navbar-item", "is-tab", "is-active", "m-0", "p-1"]
+            | otherwise = ["navbar-item", "is-tab", "m-0", "p-1"]
           cls = classList $ map (\tag -> (tag, True)) clss
        in el "a" [cls, onClick]
 
@@ -153,7 +153,7 @@ render (ui, ss) = do
 
   ui' <-
     div
-      [classList [("container is-fullheight", True)]]
+      [classList [("container is-fullheight is-size-7 m-4 p-4", True)]]
       [ cssLink "https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
       , cssLink "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.2/css/all.min.css"
       , handleNavbar ui <$> renderNavbar (uiTab ui)

--- a/app/toolbox-server/Toolbox/Render.hs
+++ b/app/toolbox-server/Toolbox/Render.hs
@@ -56,12 +56,12 @@ iconText ico txt =
         , span [onClick] [text txt]
         ]
 
-renderInbox :: UIState -> Inbox -> Widget HTML Event -- (Maybe Text)
+renderInbox :: UIState -> Inbox -> Widget HTML Event
 renderInbox ui m =
   ul [] $ map eachRender filtered
   where
     tab = uiTab ui
-    mexpandedModu = uiModule ui
+    mexpandedModu = uiModuleExpanded ui
     chan = case tab of
       TabSession -> Session
       TabModuleGraph -> Session
@@ -69,7 +69,7 @@ renderInbox ui m =
       TabTiming -> Timing
     filtered = M.toList $ M.filterWithKey (\(c, _) _ -> chan == c) m
 
-    eachRender :: (ChanModule, Text) -> Widget HTML Event -- (Maybe Text)
+    eachRender :: (ChanModule, Text) -> Widget HTML Event
     eachRender ((_, modu), v) =
       let modinfo
             | mexpandedModu == Just modu =
@@ -146,8 +146,9 @@ render (ui, ss) = do
       handleNavbar oldUI _ = oldUI
 
       handleMainPanel :: UIState -> Event -> UIState
-      handleMainPanel oldUI (ExpandModuleEv mexpandedModu') = oldUI {uiModule = mexpandedModu'}
+      handleMainPanel oldUI (ExpandModuleEv mexpandedModu') = oldUI {uiModuleExpanded = mexpandedModu'}
       handleMainPanel oldUI (HoverOnModuleEv mhoverModu') = oldUI {uiModuleHover = mhoverModu'}
+      handleMainPanel oldUI (ClickOnModuleEv mclickedModu') = oldUI {uiModuleClick = mclickedModu'}
       handleMainPanel oldUI _ = oldUI
 
   ui' <-

--- a/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
+++ b/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
@@ -249,11 +249,11 @@ renderModuleGraphSVG timing clustering grVisInfo mhovered =
    in div [classList [("is-fullwidth", True)]] [svgElement]
 
 renderSubgraph ::
+  Map ModuleName Timer ->
   [(ModuleName, GraphVisInfo)] ->
-  [(Text, [Text])] ->
   Maybe Text ->
   Widget HTML Event
-renderSubgraph subgraphs clustering mselected =
+renderSubgraph timing subgraphs mselected =
   case mselected of
     Nothing -> text "no module cluster is selected"
     Just selected ->
@@ -261,9 +261,8 @@ renderSubgraph subgraphs clustering mselected =
         Nothing ->
           text [fmt|cannot find the subgraph for the module cluster {selected}|]
         Just subgraph ->
-          renderModuleGraphSVG mempty [] subgraph Nothing
-
--- text [fmt|The module cluster {selected}: \n{show subgraph}|]
+          let tempclustering = fmap (\(name,_,_,_,_) -> (name, [name])) $ gviNodes subgraph
+          in renderModuleGraphSVG timing tempclustering subgraph Nothing
 
 renderModuleGraph :: UIState -> ServerState -> Widget HTML Event
 renderModuleGraph ui ss =
@@ -280,7 +279,7 @@ renderModuleGraph ui ss =
                   Nothing -> []
                   Just grVisInfo ->
                     [ renderModuleGraphSVG timing clustering grVisInfo (uiModuleHover ui)
-                    , renderSubgraph (serverModuleSubgraph ss) clustering (uiModuleClick ui)
+                    , renderSubgraph timing (serverModuleSubgraph ss) (uiModuleClick ui)
                     ]
               )
                 ++ [pre [] [text $ formatModuleGraphInfo (sessionModuleGraph sessionInfo)]]

--- a/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
+++ b/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
@@ -13,6 +13,7 @@ import Concur.Replica
     classList,
     div,
     height,
+    onClick,
     onMouseEnter,
     onMouseLeave,
     pre,
@@ -182,6 +183,7 @@ renderModuleGraphSVG timing clustering grVisInfo mhovered =
         S.rect
           [ HoverOnModuleEv (Just name) <$ onMouseEnter
           , HoverOnModuleEv Nothing <$ onMouseLeave
+          , ClickOnModuleEv (Just name) <$ onClick
           , SP.x (T.pack $ show (x + w * offXFactor))
           , SP.y (T.pack $ show (y + h * offYFactor + h - 12))
           , width (T.pack $ show (w * aFactor))
@@ -236,9 +238,9 @@ renderModuleGraphSVG timing clustering grVisInfo mhovered =
           [ width "100%"
           , SP.viewBox
               ( "0 0 "
-                  <> T.pack (show (canvasWidth + 300)) -- i don't understand why it's incorrect
+                  <> T.pack (show (canvasWidth + 100)) -- i don't understand why it's incorrect
                   <> " "
-                  <> T.pack (show (canvasHeight + 300))
+                  <> T.pack (show (canvasHeight + 100))
               )
           , SP.version "1.1"
           , xmlns
@@ -260,7 +262,9 @@ renderModuleGraph ui ss =
             ( ( case serverModuleGraph ss of
                   Nothing -> []
                   Just grVisInfo ->
-                    [renderModuleGraphSVG timing clustering grVisInfo (uiModuleHover ui)]
+                    [ renderModuleGraphSVG timing clustering grVisInfo (uiModuleHover ui)
+                    , text (T.pack $ show (uiModuleClick ui))
+                    ]
               )
                 ++ [pre [] [text $ formatModuleGraphInfo (sessionModuleGraph sessionInfo)]]
             )

--- a/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
+++ b/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
@@ -164,8 +164,9 @@ renderModuleGraphSVG ::
   Map Text Timer ->
   [(Text, [Text])] ->
   GraphVisInfo ->
+  Maybe Text ->
   Widget HTML Event
-renderModuleGraphSVG timing clustering grVisInfo =
+renderModuleGraphSVG timing clustering grVisInfo mhovered =
   let Dim canvasWidth canvasHeight = gviCanvasDim grVisInfo
       edge (EdgeLayout _ _ xys) =
         S.polyline
@@ -186,7 +187,7 @@ renderModuleGraphSVG timing clustering grVisInfo =
           , width (T.pack $ show (w * aFactor))
           , height "20"
           , SP.stroke "dimgray"
-          , SP.fill "ivory"
+          , SP.fill $ if Just name == mhovered then "honeydew" else "ivory"
           ]
           []
       box1 (NodeLayout _ (Point x y) (Dim w h)) =
@@ -259,9 +260,7 @@ renderModuleGraph ui ss =
             ( ( case serverModuleGraph ss of
                   Nothing -> []
                   Just grVisInfo ->
-                    [ pre [] [text $ T.pack (show (uiModuleHover ui))]
-                    , renderModuleGraphSVG timing clustering grVisInfo
-                    ]
+                    [renderModuleGraphSVG timing clustering grVisInfo (uiModuleHover ui)]
               )
                 ++ [pre [] [text $ formatModuleGraphInfo (sessionModuleGraph sessionInfo)]]
             )

--- a/app/toolbox-server/Toolbox/Server/Types.hs
+++ b/app/toolbox-server/Toolbox/Server/Types.hs
@@ -2,6 +2,7 @@ module Toolbox.Server.Types
   ( type ChanModule,
     type Inbox,
     Tab (..),
+    Event (..),
     UIState (..),
     ServerState (..),
     incrementSN,
@@ -31,9 +32,12 @@ type Inbox = Map ChanModule Text
 data Tab = TabSession | TabModuleGraph | TabCheckImports | TabTiming
   deriving (Eq)
 
+data Event = TabEv Tab | ExpandModuleEv (Maybe Text)
+
 data UIState = UIState
   { uiTab :: Tab
   , uiModule :: Maybe Text
+  -- , uiModuleGraphHover :: Maybe Text
   }
 
 data Point = Point

--- a/app/toolbox-server/Toolbox/Server/Types.hs
+++ b/app/toolbox-server/Toolbox/Server/Types.hs
@@ -32,12 +32,15 @@ type Inbox = Map ChanModule Text
 data Tab = TabSession | TabModuleGraph | TabCheckImports | TabTiming
   deriving (Eq)
 
-data Event = TabEv Tab | ExpandModuleEv (Maybe Text)
+data Event
+  = TabEv Tab
+  | ExpandModuleEv (Maybe Text)
+  | HoverOnModuleEv (Maybe Text)
 
 data UIState = UIState
   { uiTab :: Tab
   , uiModule :: Maybe Text
-  -- , uiModuleGraphHover :: Maybe Text
+  , uiModuleHover :: Maybe Text
   }
 
 data Point = Point

--- a/app/toolbox-server/Toolbox/Server/Types.hs
+++ b/app/toolbox-server/Toolbox/Server/Types.hs
@@ -8,6 +8,7 @@ module Toolbox.Server.Types
     initUIState,
     -- * Server state
     ServerState (..),
+    initServerState,
     incrementSN,
     -- * graph visualization information
     Point (..),
@@ -22,9 +23,10 @@ import Data.Map.Strict (Map)
 import Data.Text (Text)
 import Toolbox.Channel
   ( Channel,
-    SessionInfo,
+    SessionInfo (..),
     Timer,
     type ModuleName,
+    emptyModuleGraphInfo,
   )
 
 type ChanModule = (Channel, Text)
@@ -106,7 +108,20 @@ data ServerState = ServerState
   , serverTiming :: Map ModuleName Timer
   , serverModuleGraph :: Maybe GraphVisInfo
   , serverModuleClustering :: [(ModuleName, [ModuleName])]
+  , serverModuleSubgraph :: [(ModuleName, GraphVisInfo)]
   }
+
+initServerState :: ServerState
+initServerState =
+  ServerState
+    { serverMessageSN = 0
+    , serverInbox = mempty
+    , serverSessionInfo = SessionInfo Nothing emptyModuleGraphInfo
+    , serverTiming = mempty
+    , serverModuleGraph = Nothing
+    , serverModuleClustering = []
+    , serverModuleSubgraph = []
+    }
 
 incrementSN :: ServerState -> ServerState
 incrementSN ss =

--- a/app/toolbox-server/Toolbox/Server/Types.hs
+++ b/app/toolbox-server/Toolbox/Server/Types.hs
@@ -3,10 +3,12 @@ module Toolbox.Server.Types
     type Inbox,
     Tab (..),
     Event (..),
+    -- * UI state
     UIState (..),
+    initUIState,
+    -- * Server state
     ServerState (..),
     incrementSN,
-
     -- * graph visualization information
     Point (..),
     Dimension (..),
@@ -36,12 +38,27 @@ data Event
   = TabEv Tab
   | ExpandModuleEv (Maybe Text)
   | HoverOnModuleEv (Maybe Text)
+  | ClickOnModuleEv (Maybe Text)
 
 data UIState = UIState
   { uiTab :: Tab
-  , uiModule :: Maybe Text
+  -- ^ current tab
+  , uiModuleExpanded :: Maybe Text
+  -- ^ expanded module in CheckImports
   , uiModuleHover :: Maybe Text
+  -- ^ module under mouse cursor in Module Graph
+  , uiModuleClick :: Maybe Text
+  -- ^ module clicked in Module Graph
   }
+
+initUIState :: UIState
+initUIState =
+  UIState
+    { uiTab = TabSession,
+      uiModuleExpanded = Nothing,
+      uiModuleHover = Nothing,
+      uiModuleClick = Nothing
+    }
 
 data Point = Point
   { pointX :: Double

--- a/app/toolbox-server/Toolbox/Util/OGDF.hs
+++ b/app/toolbox-server/Toolbox/Util/OGDF.hs
@@ -315,7 +315,7 @@ doSugiyamaLayout ga = do
     sugiyamaLayout_setCrossMin sl mh
     ohl <- newOptimalHierarchyLayout
     optimalHierarchyLayout_layerDistance ohl 5.0
-    optimalHierarchyLayout_nodeDistance ohl 1.0
-    optimalHierarchyLayout_weightBalancing ohl 0.5
+    optimalHierarchyLayout_nodeDistance ohl 0
+    optimalHierarchyLayout_weightBalancing ohl 0.1
     sugiyamaLayout_setLayout sl ohl
     call sl ga

--- a/app/toolbox-server/Toolbox/Worker.hs
+++ b/app/toolbox-server/Toolbox/Worker.hs
@@ -46,7 +46,7 @@ moduleGraphWorker var mgi = do
           , clusterStateUnclustered = smallNodes
           }
       bgr = getBiDepGraph mgi
-      (clustering_, _) = fullStep (seedClustering, makeSeedState largeNodes bgr)
+      (clustering_, _) = fullStep . fullStep $ (seedClustering, makeSeedState largeNodes bgr)
       clustering = mapMaybe convert (clusterStateClustered clustering_)
         where
           convert (Cluster i, js) = do


### PR DESCRIPTION
Module clusters are highlighted (with colored edges) when hovered and subgraph of the module cluster is shown when clicked. 