### PR TITLE
Clustering based on BFS with topological limiting

### DIFF
--- a/app/toolbox-server/Main.hs
+++ b/app/toolbox-server/Main.hs
@@ -45,13 +45,12 @@ import Toolbox.Server.Types
     initServerState,
     initUIState,
   )
-import Toolbox.Worker (moduleGraphWorker, tempWorker)
+import Toolbox.Worker (moduleGraphWorker)
 import Prelude hiding (div)
 
 data CLIMode
   = Online FilePath
   | View FilePath
-  | Temp FilePath
 
 onlineMode :: OA.Mod OA.CommandFields CLIMode
 onlineMode =
@@ -71,19 +70,10 @@ viewMode =
         (OA.progDesc "viewing saved session")
     )
 
-tempMode :: OA.Mod OA.CommandFields CLIMode
-tempMode =
-  OA.command
-    "temp"
-    ( OA.info
-        (Temp <$> OA.strOption (OA.long "session-file" <> OA.short 'f' <> OA.help "session file"))
-        (OA.progDesc "temp saved session")
-    )
-
 optsParser :: OA.ParserInfo CLIMode
 optsParser =
   OA.info
-    (OA.subparser (onlineMode <> viewMode <> tempMode) OA.<**> OA.helper)
+    (OA.subparser (onlineMode <> viewMode) OA.<**> OA.helper)
     OA.fullDesc
 
 main :: IO ()
@@ -101,14 +91,6 @@ main = do
         Right ss -> do
           var <- atomically $ newTVar ss
           webServer var
-    Temp sessionFile -> do
-      lbs <- BL.readFile sessionFile
-      case eitherDecode' lbs of
-        Left err -> print err
-        Right ss -> do
-          let sessionInfo = serverSessionInfo ss
-              mginfo = sessionModuleGraph sessionInfo
-          tempWorker mginfo
 
 updateInterval :: NominalDiffTime
 updateInterval = secondsToNominalDiffTime (fromRational (1 / 2))

--- a/app/toolbox-server/Main.hs
+++ b/app/toolbox-server/Main.hs
@@ -45,12 +45,13 @@ import Toolbox.Server.Types
     initServerState,
     initUIState,
   )
-import Toolbox.Worker (moduleGraphWorker)
+import Toolbox.Worker (moduleGraphWorker, tempWorker)
 import Prelude hiding (div)
 
 data CLIMode
   = Online FilePath
   | View FilePath
+  | Temp FilePath
 
 onlineMode :: OA.Mod OA.CommandFields CLIMode
 onlineMode =
@@ -70,10 +71,19 @@ viewMode =
         (OA.progDesc "viewing saved session")
     )
 
+tempMode :: OA.Mod OA.CommandFields CLIMode
+tempMode =
+  OA.command
+    "temp"
+    ( OA.info
+        (Temp <$> OA.strOption (OA.long "session-file" <> OA.short 'f' <> OA.help "session file"))
+        (OA.progDesc "temp saved session")
+    )
+
 optsParser :: OA.ParserInfo CLIMode
 optsParser =
   OA.info
-    (OA.subparser (onlineMode <> viewMode) OA.<**> OA.helper)
+    (OA.subparser (onlineMode <> viewMode <> tempMode) OA.<**> OA.helper)
     OA.fullDesc
 
 main :: IO ()
@@ -91,6 +101,14 @@ main = do
         Right ss -> do
           var <- atomically $ newTVar ss
           webServer var
+    Temp sessionFile -> do
+      lbs <- BL.readFile sessionFile
+      case eitherDecode' lbs of
+        Left err -> print err
+        Right ss -> do
+          let sessionInfo = serverSessionInfo ss
+              mginfo = sessionModuleGraph sessionInfo
+          tempWorker mginfo
 
 updateInterval :: NominalDiffTime
 updateInterval = secondsToNominalDiffTime (fromRational (1 / 2))

--- a/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
+++ b/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
@@ -116,7 +116,7 @@ analyze graphInfo =
               Nothing -> Right acc'
               Just j' -> Left (acc' ++ [j'], j')
       legs = fmap leg (initials L.\\ orphans)
-      larges = filterOutSmallNodes graphInfo
+      larges = filterOutSmallNodes modDep
       largeNames = mapMaybe (\i -> IM.lookup i (mginfoModuleNameMap graphInfo)) larges
    in "intials: " <> (T.pack $ show initials) <> ",\n"
         <> "terminals: "

--- a/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
+++ b/app/toolbox-server/Toolbox/Render/ModuleGraph.hs
@@ -81,10 +81,8 @@ import Toolbox.Server.Types
     UIState (..),
     transposeGraphVis,
   )
-import Toolbox.Util.Graph
-  ( filterOutSmallNodes,
-    makeRevDep,
-  )
+import Toolbox.Util.Graph.Builder (makeRevDep)
+import Toolbox.Util.Graph.Cluster (filterOutSmallNodes)
 import Toolbox.Util.OGDF
   ( appendText,
     doSugiyamaLayout,

--- a/app/toolbox-server/Toolbox/Worker.hs
+++ b/app/toolbox-server/Toolbox/Worker.hs
@@ -22,13 +22,15 @@ import Toolbox.Server.Types
     ServerState (..),
     incrementSN,
   )
-import Toolbox.Util.Graph
+import Toolbox.Util.Graph.Builder
+  ( makeBiDep,
+    makeRevDep,
+  )
+import Toolbox.Util.Graph.Cluster
   ( ClusterState (..),
     ClusterVertex (..),
     fullStep,
-    makeBiDep,
     makeReducedGraphReversedFromModuleGraph,
-    makeRevDep,
     makeSeedState,
   )
 

--- a/app/toolbox-server/Toolbox/Worker.hs
+++ b/app/toolbox-server/Toolbox/Worker.hs
@@ -41,14 +41,6 @@ import Toolbox.Util.Graph.Cluster
 moduleGraphWorker :: TVar ServerState -> ModuleGraphInfo -> IO ()
 moduleGraphWorker var mgi = do
   grVisInfo <- layOutGraph modNameMap reducedGraphReversed
-  putStrLn "########"
-  F.for_ divisions $ \(i, js) ->
-    F.for_ (IM.lookup i modNameMap) $ \clusterName ->
-      print (clusterName, length js)
-  putStrLn "********"
-  F.for_ clustering $ \(c, js) ->
-    print (c, length js)
-  putStrLn "%%%%%%%%"
   atomically $
     modifyTVar' var $ \ss ->
       incrementSN $

--- a/app/toolbox-server/Toolbox/Worker.hs
+++ b/app/toolbox-server/Toolbox/Worker.hs
@@ -35,12 +35,12 @@ import Toolbox.Util.Graph.Cluster
     ClusterVertex (..),
     filterOutSmallNodes,
     fullStep,
-    makeReducedGraph,
     makeSeedState,
+    reduceGraphByPath,
   )
 
-makeReducedGraphReversedFromModuleGraph :: ModuleGraphInfo -> IntMap [Int]
-makeReducedGraphReversedFromModuleGraph mgi =
+reduceModuleRevDepByPath :: ModuleGraphInfo -> IntMap [Int]
+reduceModuleRevDepByPath mgi =
   let modDep = mginfoModuleDep mgi
       nVtx = F.length $ mginfoModuleNameMap mgi
       es = makeEdges modDep
@@ -48,14 +48,14 @@ makeReducedGraphReversedFromModuleGraph mgi =
       seeds = filterOutSmallNodes modDep
       tordVtxs = reverse $ mginfoModuleTopSorted mgi
       tordSeeds = filter (`elem` seeds) tordVtxs
-      reducedGraph = makeReducedGraph g tordSeeds
+      reducedGraph = reduceGraphByPath g tordSeeds
    in makeRevDep reducedGraph
 
 moduleGraphWorker :: TVar ServerState -> ModuleGraphInfo -> IO ()
 moduleGraphWorker var mgi = do
   let modNameMap = mginfoModuleNameMap mgi
       reducedGraphReversed =
-        makeReducedGraphReversedFromModuleGraph mgi
+        reduceModuleRevDepByPath mgi
   grVisInfo <- layOutGraph modNameMap reducedGraphReversed
   let allNodes = IM.keys modNameMap
       largeNodes = IM.keys reducedGraphReversed

--- a/app/toolbox-server/Toolbox/Worker.hs
+++ b/app/toolbox-server/Toolbox/Worker.hs
@@ -95,7 +95,7 @@ moduleGraphWorker var mgi = do
           pure (clusterName, members)
 
 maxSubGraphSize :: Int
-maxSubGraphSize = 30 -- 1000 -- 100 -- 30
+maxSubGraphSize = 30
 
 layOutModuleSubgraph ::
   ModuleGraphInfo ->

--- a/app/toolbox-server/Toolbox/Worker.hs
+++ b/app/toolbox-server/Toolbox/Worker.hs
@@ -8,12 +8,12 @@ where
 
 import Control.Concurrent.STM (TVar, atomically, modifyTVar')
 import Data.Bifunctor (second)
-import qualified Data.Foldable as F
+import Data.Foldable qualified as F
 import Data.Function (on)
 import Data.Functor.Identity (runIdentity)
 import Data.Graph (buildG)
-import qualified Data.IntMap as IM
-import qualified Data.List as L
+import Data.IntMap qualified as IM
+import Data.List qualified as L
 import Data.Maybe (mapMaybe)
 import PyF (fmt)
 import Toolbox.Channel

--- a/src/Toolbox/Util/Graph/Builder.hs
+++ b/src/Toolbox/Util/Graph/Builder.hs
@@ -1,0 +1,34 @@
+module Toolbox.Util.Graph.Builder
+  ( makeEdges,
+    makeRevDep,
+    makeBiDep,
+  ) where
+
+import Data.Discrimination (inner)
+import Data.Discrimination.Grouping (grouping)
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IM
+import qualified Data.List as L
+
+-- | graph to edge list
+makeEdges :: IntMap [Int] -> [(Int, Int)]
+makeEdges = concatMap (\(i, js) -> fmap (i,) js) . IM.toList
+
+-- | reverse dependency graph
+makeRevDep :: IntMap [Int] -> IntMap [Int]
+makeRevDep deps = IM.foldlWithKey step emptyMap deps
+  where
+    emptyMap = fmap (const []) deps
+    step !acc i js =
+      L.foldl' (\(!acc') j -> IM.insertWith (<>) j [i] acc') acc js
+
+-- | bi-dependency graph: (dep, revdep) per each vertex
+makeBiDep :: IntMap [Int] -> IntMap ([Int], [Int])
+makeBiDep dep =
+  let revDep = makeRevDep dep
+      -- NOTE: The @inner@ join function has O(n) complexity using radix sort.
+      biDep = concat $ inner grouping joiner fst fst (IM.toList dep) (IM.toList revDep)
+        where
+          joiner (i, js) (_, ks) = (i, (js, ks))
+   in IM.fromList biDep
+

--- a/src/Toolbox/Util/Graph/Builder.hs
+++ b/src/Toolbox/Util/Graph/Builder.hs
@@ -2,13 +2,14 @@ module Toolbox.Util.Graph.Builder
   ( makeEdges,
     makeRevDep,
     makeBiDep,
-  ) where
+  )
+where
 
 import Data.Discrimination (inner)
 import Data.Discrimination.Grouping (grouping)
 import Data.IntMap (IntMap)
-import qualified Data.IntMap as IM
-import qualified Data.List as L
+import Data.IntMap qualified as IM
+import Data.List qualified as L
 
 -- | graph to edge list
 makeEdges :: IntMap [Int] -> [(Int, Int)]
@@ -31,4 +32,3 @@ makeBiDep dep =
         where
           joiner (i, js) (_, ks) = (i, (js, ks))
    in IM.fromList biDep
-

--- a/src/Toolbox/Util/Graph/Cluster.hs
+++ b/src/Toolbox/Util/Graph/Cluster.hs
@@ -7,11 +7,15 @@ module Toolbox.Util.Graph.Cluster
     GraphState (..),
     ICVertex (..),
     annotateLevel,
+
+    -- * reduction with clustering
     diffCluster,
     filterOutSmallNodes,
     fullStep,
-    makeReducedGraph,
     makeSeedState,
+
+    -- * reduction without clustering
+    reduceGraphByPath,
 
     -- * invariant checks
     degreeInvariant,
@@ -176,9 +180,10 @@ nodeSizeLimit = 150
 annotateLevel :: Int -> Tree a -> Tree (Int, a)
 annotateLevel root (Node x ys) = Node (root, x) (fmap (annotateLevel (root + 1)) ys)
 
--- | strip down graph to a given topologically ordered subset
-makeReducedGraph :: Graph -> [Int] -> IntMap [Int]
-makeReducedGraph g tordList = IM.fromList $ go tordList
+-- | Strip down graph to a given topologically ordered subset
+--   with edges by path-connectedness
+reduceGraphByPath :: Graph -> [Int] -> IntMap [Int]
+reduceGraphByPath g tordList = IM.fromList $ go tordList
   where
     go ys =
       case ys of

--- a/test/Toolbox/Util/Graph/BFSSpec.hs
+++ b/test/Toolbox/Util/Graph/BFSSpec.hs
@@ -8,11 +8,11 @@ import Test.Hspec
     it,
     shouldBe,
   )
-import Toolbox.Util.Graph (makeBiDep)
 import Toolbox.Util.Graph.BFS
   ( runMultiseedStagedBFS,
     runStagedBFS,
   )
+import Toolbox.Util.Graph.Builder (makeBiDep)
 
 testGraph :: [(Int, [Int])]
 testGraph =

--- a/test/Toolbox/Util/Graph/BFSSpec.hs
+++ b/test/Toolbox/Util/Graph/BFSSpec.hs
@@ -40,5 +40,5 @@ spec =
       let result = runIdentity $ runStagedBFS (\_ -> pure ()) undirectedGraph 5
       result `shouldBe` [[5], [4, 7, 8, 2], [9, 10, 6, 1], [3]]
     it "should get correct BFS search result with multiple seed for undirected graph" $ do
-      let result = runIdentity $ runMultiseedStagedBFS (\_ -> pure ()) undirectedGraph [2, 9]
+      let result = runIdentity $ runMultiseedStagedBFS (\_ -> pure ()) undirectedGraph [(2, Nothing), (9, Nothing)]
       result `shouldBe` [(2, [[2], [1, 4, 5, 6], [3]]), (9, [[9], [8, 7], [10]])]

--- a/test/Toolbox/Util/Graph/ClusterSpec.hs
+++ b/test/Toolbox/Util/Graph/ClusterSpec.hs
@@ -57,10 +57,11 @@ testGraphInfo =
 spec :: Spec
 spec =
   describe "Toolbox.Util.Graph greedy downward clustering" $ do
-    let bgr = makeBiDep $ mginfoModuleDep testGraphInfo
+    let modDep = mginfoModuleDep testGraphInfo
+        bgr = makeBiDep modDep
         allNodes = IM.keys $ mginfoModuleNameMap testGraphInfo
         nNodes = length allNodes
-        largeNodes = filterOutSmallNodes testGraphInfo
+        largeNodes = filterOutSmallNodes modDep
         smallNodes = allNodes L.\\ largeNodes
         seeds =
           ClusterState

--- a/test/Toolbox/Util/Graph/ClusterSpec.hs
+++ b/test/Toolbox/Util/Graph/ClusterSpec.hs
@@ -1,4 +1,4 @@
-module Toolbox.Util.GraphSpec (spec) where
+module Toolbox.Util.Graph.ClusterSpec (spec) where
 
 import Data.IntMap qualified as IM
 import Data.List qualified as L
@@ -9,13 +9,13 @@ import Test.Hspec
     shouldBe,
   )
 import Toolbox.Channel (ModuleGraphInfo (..))
-import Toolbox.Util.Graph
+import Toolbox.Util.Graph.Builder (makeBiDep)
+import Toolbox.Util.Graph.Cluster
   ( ClusterState (..),
     ClusterVertex (..),
     degreeInvariant,
     filterOutSmallNodes,
     fullStep,
-    makeBiDep,
     makeSeedState,
     totalNumberInvariant,
   )


### PR DESCRIPTION
Clustered node items are limited in the range between the previous and the next large node in topological order. 
Clustering algorithm uses interleaved multi-seed staged BFS, i.e. BFS stage by stage rotating the seed (rotation order is fixed so it's greedy). 